### PR TITLE
Give proxy precedence over history api fallback

### DIFF
--- a/src/jspm-hmr-server.ts
+++ b/src/jspm-hmr-server.ts
@@ -47,18 +47,6 @@ export function createServer(options: ServerOptions): JspmHmrServer {
   //   'Access-Control-Allow-Credentials': 'true',
   // };
 
-  // Apply routing rewrites to serve /index.html for SPA Applications
-
-  if (options.fallback) {
-    const fallback = options.fallback === true ? '/index.html' : options.fallback;
-    console.log('history api fallback active', fallback);
-
-    app.use(historyApiFallback({
-      index: fallback, verbose: !!options.verbose,
-    }));
-  }
-
-
   // Proxy
   if (options.proxy) {
     const proxyTarget = options.proxy;
@@ -73,6 +61,18 @@ export function createServer(options: ServerOptions): JspmHmrServer {
       });
     });
   }
+
+  // Apply routing rewrites to serve /index.html for SPA Applications
+
+  if (options.fallback) {
+    const fallback = options.fallback === true ? '/index.html' : options.fallback;
+    console.log('history api fallback active', fallback);
+
+    app.use(historyApiFallback({
+      index: fallback, verbose: !!options.verbose,
+    }));
+  }
+
 
   // Static files & Cache
   const staticRoot = options.path || '.';

--- a/test/jspm-hmr-server.spec.ts
+++ b/test/jspm-hmr-server.spec.ts
@@ -107,7 +107,11 @@ describe('testing jspmHmrServer features', () => {
         done();
       }).listen(TARGET_PORT);
 
-      http.request(`${SERVER_ADDRESS}/api/search?param=value`).end();
+      http.request({
+        port: SERVER_PORT,
+        path: '/api/search?param=value',
+        headers: {'accept': '*/*'}
+      }).end();
     });
   });
 


### PR DESCRIPTION
Currently the middleware used for the --fallback option is executed before the --proxy middleware. This causes all requests to return index.html, even the ones to the path specified with --proxy-route, in effect making it so --proxy has no effect at all in combination with --fallback. 
This change switches the middlewares around so the proxy middleware will proxy any requests to its specified path.